### PR TITLE
Fix typo, bump hugo-coder theme and hugo to latest versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Enable version updates for GitHub action workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    # Check for updates to GitHub Actions once per week
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.123.8
+      HUGO_VERSION: 0.140.2
     steps:
       - name: Install Hugo CLI
         run: |
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Build with Hugo
@@ -61,7 +61,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"          
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
 
@@ -75,5 +75,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 public/
 resources/
+.hugo_build.lock

--- a/content/about.md
+++ b/content/about.md
@@ -14,4 +14,4 @@ I've been active within open source communities for many years.
 Before learning software development, I was working on community moderation, release testing and translation for the [Brave](https://brave.com/) browser project. 
 I have since moved on to being an active developer within various other open source projects. Some of the programming languages that I work with on a regular basis are Go, Python and C++.
 
-You will find many of my open source projects, and more information about them, over on the [projects](/projects) page. Most notably, ai am a member of the team of core developers working on [Fyne](https://fyne.io). My most popular project is [Rymdport](https://rymdport.github.io) at the moment. 
+You will find many of my open source projects, and more information about them, over on the [projects](/projects) page. Most notably, I am a member of the team of core developers working on [Fyne](https://fyne.io). My most popular project is [Rymdport](https://rymdport.github.io) at the moment. 

--- a/hugo.toml
+++ b/hugo.toml
@@ -4,7 +4,8 @@ theme = "hugo-coder"
 languagecode = "en"
 defaultcontentlanguage = "en"
 
-paginate = 20
+[pagination]
+  pagerSize = 20
 
 [markup.highlight]
 style = "github-dark"


### PR DESCRIPTION
This PR fixes a typo I spotted in `about.md`.
This PR also brings minor improvements to the repo: it bumps the theme to latest version so that it can run with latest hugo version 0.140.2 and it adds dependency check with dependabot. I hope you like these changes!